### PR TITLE
Fix repr() checks for Python 3.10

### DIFF
--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -1845,7 +1845,7 @@ class TestBasicServer(object):
         Ensure stream string representation is appropriate.
         """
         s = h2.stream.H2Stream(4, None, 12, 14)
-        assert repr(s) == "<H2Stream id:4 state:<StreamState.IDLE: 0>>"
+        assert repr(s) == "<H2Stream id:4 state:StreamState.IDLE>"
 
 
 def sanity_check_data_frame(data_frame,

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -209,7 +209,7 @@ class TestEventReprs(object):
 
         assert repr(e) == (
             "<RemoteSettingsChanged changed_settings:{ChangedSetting("
-            "setting=SettingCodes.INITIAL_WINDOW_SIZE, original_value=65536, "
+            "setting=INITIAL_WINDOW_SIZE, original_value=65536, "
             "new_value=32768)}>"
         )
 
@@ -251,7 +251,7 @@ class TestEventReprs(object):
 
         assert repr(e) == (
             "<StreamReset stream_id:919, "
-            "error_code:ErrorCodes.ENHANCE_YOUR_CALM, remote_reset:False>"
+            "error_code:ENHANCE_YOUR_CALM, remote_reset:False>"
         )
 
     def test_pushedstreamreceived_repr(self):
@@ -286,7 +286,7 @@ class TestEventReprs(object):
 
         assert repr(e) == (
             "<SettingsAcknowledged changed_settings:{ChangedSetting("
-            "setting=SettingCodes.INITIAL_WINDOW_SIZE, original_value=65536, "
+            "setting=INITIAL_WINDOW_SIZE, original_value=65536, "
             "new_value=32768)}>"
         )
 
@@ -319,7 +319,7 @@ class TestEventReprs(object):
         e.additional_data = additional_data
 
         assert repr(e) == (
-            "<ConnectionTerminated error_code:ErrorCodes.INADEQUATE_SECURITY, "
+            "<ConnectionTerminated error_code:INADEQUATE_SECURITY, "
             "last_stream_id:33, additional_data:%s>" % data_repr
         )
 


### PR DESCRIPTION
Stating Python 3.10 alpha 7, repr() was modified as follow:

bpo-40066: Enum: adjust repr() to show only enum and member name
(not value, nor angle brackets) and str() to show only member name.
Update and improve documentation to match.

bpo-40066: Enum’s repr() and str() have changed: repr() is
now EnumClass.MemberName and str() is MemberName. Additionally,
stdlib Enum’s whose contents are available as module attributes,
such as RegexFlag.IGNORECASE, have their repr() as module.name,
e.g. re.IGNORECASE.

See https://bugs.python.org/issue40066

This commit fixes the assertions to match the new repr() behavior.

Fix #1253