### PR TITLE
Fix TE header name in error message

### DIFF
--- a/src/h2/utilities.py
+++ b/src/h2/utilities.py
@@ -288,7 +288,7 @@ def _reject_te(headers, hdr_validation_flags):
         if header[0] in (b'te', u'te'):
             if header[1].lower() not in (b'trailers', u'trailers'):
                 raise ProtocolError(
-                    "Invalid value for Transfer-Encoding header: %s" %
+                    "Invalid value for TE header: %s" %
                     header[1]
                 )
 

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -162,9 +162,9 @@ class TestInvalidFrameSequences(object):
         request_event = events[0]
         assert request_event.headers == headers
 
-    def test_transfer_encoding_trailers_is_valid(self, frame_factory):
+    def test_te_trailers_is_valid(self, frame_factory):
         """
-        Transfer-Encoding trailers is allowed by the filter.
+        `te: trailers` is allowed by the filter.
         """
         headers = (
             self.base_request_headers + [('te', 'trailers')]


### PR DESCRIPTION
This is closely related (the TE request header specifies the transfer encodings the user agent is willing to accept), but the header name is `TE`, not `Transfer-Encodings`. 😛 