### PR TITLE
Simplifies conditional logic and Refactor Multiple Functions

### DIFF
--- a/examples/asyncio/wsgi-server.py
+++ b/examples/asyncio/wsgi-server.py
@@ -603,8 +603,7 @@ class Stream:
 
         # We only need the status code
         status = self._response_status.split(" ", 1)[0]
-        headers = [(":status", status)]
-        headers.extend(self._response_headers)
+        headers = [(":status", status), *self._response_headers]
         event = self._protocol.send_response(self.stream_id, headers)
         event.wait()
         return

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -47,10 +47,7 @@ class TestFlowControl(object):
         """
         When data is sent on a stream, the flow control window should drop.
         """
-        c = h2.connection.H2Connection()
-        c.send_headers(1, self.example_request_headers)
-        c.send_data(1, b'some data')
-
+        c = self._extracted_from_test_flow_control_is_limited_by_connection_3()
         remaining_length = self.DEFAULT_FLOW_WINDOW - len(b'some data')
         assert (c.local_flow_control_window(1) == remaining_length)
 
@@ -108,13 +105,17 @@ class TestFlowControl(object):
         The flow control window is limited by the flow control of the
         connection.
         """
-        c = h2.connection.H2Connection()
-        c.send_headers(1, self.example_request_headers)
-        c.send_data(1, b'some data')
+        c = self._extracted_from_test_flow_control_is_limited_by_connection_3()
         c.send_headers(3, self.example_request_headers)
 
         remaining_length = self.DEFAULT_FLOW_WINDOW - len(b'some data')
         assert (c.local_flow_control_window(3) == remaining_length)
+
+    def _extracted_from_test_flow_control_is_limited_by_connection_3(self):
+        result = h2.connection.H2Connection()
+        result.send_headers(1, self.example_request_headers)
+        result.send_data(1, b'some data')
+        return result
 
     def test_remote_flow_control_is_limited_by_connection(self, frame_factory):
         """


### PR DESCRIPTION
- Merges together multiply nested `if` conditions into one.
  > Too much nesting can make code difficult to understand, and this is especially true in Python, where there are no brackets to help out with the delineation of different nesting levels.
- Simplifies conditional logic using De Morgan's Identity
  > When reading logical statements it is important for them to be as simple as possible. This proposal applies De Morgan's identity to simplify code by removing double negatives or pushing negations deeper into statements.
- Removes conditional tests where the conditional is always `True` or `False`
  > This refactoring will re-structure conditionals where determines that one of the tests is always True or False. This reveals the actual logic of the conditional to the reader, making the code easier to understand.
