### PR TITLE
Fix repr() checks for Python 3.11

### DIFF
--- a/test/test_events.py
+++ b/test/test_events.py
@@ -209,7 +209,7 @@ class TestEventReprs(object):
 
         assert repr(e) == (
             "<RemoteSettingsChanged changed_settings:{ChangedSetting("
-            "setting=SettingCodes.INITIAL_WINDOW_SIZE, original_value=65536, "
+            "setting=4, original_value=65536, "
             "new_value=32768)}>"
         )
 
@@ -251,7 +251,7 @@ class TestEventReprs(object):
 
         assert repr(e) == (
             "<StreamReset stream_id:919, "
-            "error_code:ErrorCodes.ENHANCE_YOUR_CALM, remote_reset:False>"
+            "error_code:11, remote_reset:False>"
         )
 
     def test_pushedstreamreceived_repr(self):
@@ -286,7 +286,7 @@ class TestEventReprs(object):
 
         assert repr(e) == (
             "<SettingsAcknowledged changed_settings:{ChangedSetting("
-            "setting=SettingCodes.INITIAL_WINDOW_SIZE, original_value=65536, "
+            "setting=4, original_value=65536, "
             "new_value=32768)}>"
         )
 
@@ -319,7 +319,7 @@ class TestEventReprs(object):
         e.additional_data = additional_data
 
         assert repr(e) == (
-            "<ConnectionTerminated error_code:ErrorCodes.INADEQUATE_SECURITY, "
+            "<ConnectionTerminated error_code:12, "
             "last_stream_id:33, additional_data:%s>" % data_repr
         )
 


### PR DESCRIPTION
In Python 3.11, repr() was modified, this commit fixes the
assertions to match the new repr() behavior.

Fix #1268