### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tox:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # bump to -latest or -22.04 once we drop py36
     strategy:
       max-parallel: 5
       matrix:
@@ -18,11 +18,11 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"
-        - pypy3
+        - "pypy3.9"
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tox
@@ -30,6 +30,8 @@ jobs:
         python -m pip install --upgrade pip setuptools
         pip install --upgrade tox tox-gh-actions
     - name: Install h2spec
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         .github/workflows/install_h2spec.sh
     - name: Initialize tox envs

--- a/.github/workflows/install_h2spec.sh
+++ b/.github/workflows/install_h2spec.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
 set -e
-set -x
 
 # For some reason it helps to have this here.
-echo $(curl -s https://api.github.com/repos/summerwind/h2spec/releases/latest)
+echo $(curl -s --url https://api.github.com/repos/summerwind/h2spec/releases/latest --header "authorization: Bearer ${GITHUB_TOKEN}")
 
 # We want to get the latest release of h2spec. We do that by asking the
 # Github API for it, and then parsing the JSON for the appropriate kind of
 # binary. Happily, the binary is always called "h2spec" so we don't need
 # even more shenanigans to get this to work.
-TARBALL=$(curl -s https://api.github.com/repos/summerwind/h2spec/releases/latest | jq --raw-output '.assets[] | .browser_download_url | select(endswith("linux_amd64.tar.gz"))')
+TARBALL=$(curl -s --url https://api.github.com/repos/summerwind/h2spec/releases/latest --header "authorization: Bearer ${GITHUB_TOKEN}" | jq --raw-output '.assets[] | .browser_download_url | select(endswith("linux_amd64.tar.gz"))')
 
 curl -s -L "$TARBALL" -o h2spec.tgz
 tar xvf h2spec.tgz

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, pypy3, lint, docs, packaging
+envlist = py36, py37, py38, py39, py310, py311, pypy3, lint, docs, packaging
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.8: py38
     3.9: py39, lint, docs, packaging, h2spec
     3.10: py310
+    3.11: py311
     pypy3: pypy3
 
 [testenv]
@@ -33,7 +34,7 @@ commands = flake8 src/ test/
 [testenv:docs]
 deps =
     sphinx>=4.0.2,<5
-whitelist_externals = make
+allowlist_externals = make
 changedir = {toxinidir}/docs
 commands =
     make clean
@@ -42,10 +43,10 @@ commands =
 [testenv:packaging]
 basepython = python3.9
 deps =
-    check-manifest==0.46
-    readme-renderer==29.0
+    check-manifest==0.49
+    readme-renderer==37.3
     twine>=3.4.1,<4
-whitelist_externals = rm
+allowlist_externals = rm
 commands =
     rm -rf dist/
     check-manifest
@@ -56,7 +57,7 @@ commands =
 basepython = {[testenv:packaging]basepython}
 deps =
     {[testenv:packaging]deps}
-whitelist_externals = {[testenv:packaging]whitelist_externals}
+allowlist_externals = {[testenv:packaging]allowlist_externals}
 commands =
     {[testenv:packaging]commands}
     twine upload dist/*
@@ -72,6 +73,6 @@ commands =
 basepython = python3.8
 deps =
     twisted[tls]==20.3.0
-whitelist_externals = {toxinidir}/test/h2spectest.sh
+allowlist_externals = {toxinidir}/test/h2spectest.sh
 commands =
     {toxinidir}/test/h2spectest.sh


### PR DESCRIPTION
* Python 3.6 doesn't install any more on `ubuntu-latest` which currently is 22.04
* API rate limiting hit us without the correct token
* update test dependencies and fix their now incompatible config