### PR TITLE
Use 'trace' level logging to log frames in each direction.

### DIFF
--- a/src/h2/connection.py
+++ b/src/h2/connection.py
@@ -386,6 +386,10 @@ class H2Connection:
     def _prepare_for_sending(self, frames):
         if not frames:
             return
+
+        for frame in frames:
+            self.config.logger.trace("Sending frame:  %s", repr(frame))
+
         self._data_to_send += b''.join(f.serialize() for f in frames)
         assert all(f.body_len <= self.max_outbound_frame_size for f in frames)
 
@@ -498,10 +502,8 @@ class H2Connection:
         f = SettingsFrame(0)
         for setting, value in self.local_settings.items():
             f.settings[setting] = value
-        self.config.logger.debug(
-            "Send Settings frame: %s", self.local_settings
-        )
 
+        self.config.logger.trace("Sending frame: %s", repr(f))
         self._data_to_send += preamble + f.serialize()
 
     def initiate_upgrade_connection(self, settings_header=None):
@@ -1450,10 +1452,6 @@ class H2Connection:
         :returns: A list of events that the remote peer triggered by sending
             this data.
         """
-        self.config.logger.trace(
-            "Process received data on connection. Received data: %r", data
-        )
-
         events = []
         self.incoming_buffer.add_data(data)
         self.incoming_buffer.max_frame_size = self.max_inbound_frame_size

--- a/src/h2/connection.py
+++ b/src/h2/connection.py
@@ -388,7 +388,7 @@ class H2Connection:
             return
 
         for frame in frames:
-            self.config.logger.trace("Sending frame:  %s", repr(frame))
+            self.config.logger.trace("Sending frame: %s", repr(frame))
 
         self._data_to_send += b''.join(f.serialize() for f in frames)
         assert all(f.body_len <= self.max_outbound_frame_size for f in frames)


### PR DESCRIPTION
This proposal modifies the logging at 'trace' level, so that it provides HTTP/2 frame-level logging in both directions.

From my perspective this is both more useful and more consistent than the existing trace-level logging, which logs incoming data and incoming frames.

Also related: https://github.com/encode/httpcore/pull/686

**example.py:**

```python
import httpx
import logging

logging.basicConfig(
    format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
    datefmt="%Y-%m-%d %H:%M:%S",
    level=logging.INFO
)
logging.getLogger("httpcore.h2frames").setLevel(logging.DEBUG)

with httpx.Client(http2=True) as client:
    client.get("https://www.example.com/")
```

**console:**

```shell
$ python -m venv venv
$ venv/bin/pip install git+https://github.com/python-hyper/h2.git@frame-level-logging  # `h2`, updated with frame-level logging
$ venv/bin/pip install git+https://github.com/encode/httpcore.git@add-h2-logging  # `httpcore`, updated to include h2 loggers.
$ venv/bin/pip install httpx
$ venv/bin/python example.py 
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: SettingsFrame(stream_id=0, flags=[]): settings={<SettingCodes.HEADER_TABLE_SIZE: 1>: 4096, <SettingCodes.ENABLE_PUSH: 2>: 0, <SettingCodes.INITIAL_WINDOW_SIZE: 4>: 65535, <SettingCodes.MAX_FRAME_SIZE: 5>: 16384, <SettingCodes.MAX_CONCURRENT_STREAMS: 3>: 100, <SettingCodes.MAX_HEADER_LIST_SIZE: 6>: 65536}
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: WindowUpdateFrame(stream_id=0, flags=[]): window_increment=16777216
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: HeadersFrame(stream_id=1, flags=['END_HEADERS', 'END_STREAM']): exclusive=False, depends_on=0, stream_weight=0, data=<hex:82418cf1e3c2e5f23a6b...>
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: WindowUpdateFrame(stream_id=1, flags=[]): window_increment=16777216
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: SettingsFrame(stream_id=0, flags=[]): settings={1: 4096, 3: 100, 4: 1048576, 5: 16384, 6: 16384}
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: SettingsFrame(stream_id=0, flags=['ACK']): settings={}
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: WindowUpdateFrame(stream_id=0, flags=[]): window_increment=983041
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: SettingsFrame(stream_id=0, flags=['ACK']): settings={}
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: HeadersFrame(stream_id=1, flags=['END_HEADERS']): exclusive=False, depends_on=0, stream_weight=0, data=<hex:3fe11f885a839bd9ab52...>
INFO [2023-05-17 11:34:12] httpx - HTTP Request: GET https://www.example.com/ "HTTP/2 200 OK"
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Received frame: DataFrame(stream_id=1, flags=['END_STREAM']): <hex:1f8b0800c215a85d0003...>
DEBUG [2023-05-17 11:34:12] httpcore.h2frames - Sending frame: GoAwayFrame(stream_id=0, flags=[]): last_stream_id=0, error_code=0, additional_data=b''
```