### PR TITLE
Fix bug when v is None

### DIFF
--- a/src/h2/utilities.py
+++ b/src/h2/utilities.py
@@ -177,6 +177,8 @@ def authority_from_headers(headers):
         # user, so we may have unicode floating around in here. We only want
         # bytes.
         if n in (b':authority', u':authority'):
+            if v is None:
+                return None
             return v.encode('utf-8') if not isinstance(v, bytes) else v
 
     return None


### PR DESCRIPTION
When we use a library called 'wechaty', the variable `v` may be None. And at this time, it will throw an exception: `'NoneType' object has no attribute 'encode'`.