### PR TITLE
clarify RequestReceived CONTINUATION frame behavior

### DIFF
--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -23,9 +23,13 @@ class Event:
 
 class RequestReceived(Event):
     """
-    The RequestReceived event is fired whenever request headers are received.
-    This event carries the HTTP headers for the given request and the stream ID
-    of the new stream.
+    The RequestReceived event is fired whenever all of a request's headers
+    are received. This event carries the HTTP headers for the given request
+    and the stream ID of the new stream.
+    
+    In HTTP/2, headers may be sent as a HEADERS frame followed by zero or more
+    CONTINUATION frames with the final frame setting the END_HEADERS flag.
+    This event is fired after the entire sequence is received.
 
     .. versionchanged:: 2.3.0
        Changed the type of ``headers`` to :class:`HeaderTuple


### PR DESCRIPTION
To answer my own question in https://github.com/python-hyper/h2/issues/1293.