### PR TITLE
Make h2.events more typing-friendly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ dev
 
 -
 
+**API Changes (Backward Compatible)**
+
+- h2 events now have tighter type bounds, e.g. `stream_id` is guaranteed to not be `None` for most events now.
+  This simplifies downstream type checking.
+
 **Bugfixes**
 
 -

--- a/src/h2/connection.py
+++ b/src/h2/connection.py
@@ -1823,9 +1823,9 @@ class H2Connection:
 
         evt: PingReceived | PingAckReceived
         if "ACK" in frame.flags:
-            evt = PingAckReceived()
+            evt = PingAckReceived(ping_data=frame.opaque_data)
         else:
-            evt = PingReceived()
+            evt = PingReceived(ping_data=frame.opaque_data)
 
             # automatically ACK the PING with the same 'opaque data'
             f = PingFrame(0)
@@ -1833,7 +1833,6 @@ class H2Connection:
             f.opaque_data = frame.opaque_data
             frames.append(f)
 
-        evt.ping_data = frame.opaque_data
         events.append(evt)
 
         return frames, events

--- a/src/h2/connection.py
+++ b/src/h2/connection.py
@@ -1806,9 +1806,7 @@ class H2Connection:
             )
 
             # FIXME: Should we split this into one event per active stream?
-            window_updated_event = WindowUpdated()
-            window_updated_event.stream_id = 0
-            window_updated_event.delta = frame.window_increment
+            window_updated_event = WindowUpdated(stream_id=0, delta=frame.window_increment)
             stream_events = [window_updated_event]
             frames = []
 

--- a/src/h2/connection.py
+++ b/src/h2/connection.py
@@ -1972,8 +1972,7 @@ class H2Connection:
         self.config.logger.debug(
             "Received unknown extension frame (ID %d)", frame.stream_id,
         )
-        event = UnknownFrameReceived()
-        event.frame = frame
+        event = UnknownFrameReceived(frame=frame)
         return [], [event]
 
     def _local_settings_acked(self) -> dict[SettingCodes | int, ChangedSetting]:

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -433,6 +433,7 @@ class PingAckReceived(Event):
         return f"<PingAckReceived ping_data:{_bytes_representation(self.ping_data)}>"
 
 
+@dataclass(**kw_only)
 class StreamEnded(Event):
     """
     The StreamEnded event is fired whenever a stream is ended by a remote
@@ -440,9 +441,8 @@ class StreamEnded(Event):
     locally, but no further data or headers should be expected on that stream.
     """
 
-    def __init__(self) -> None:
-        #: The Stream ID of the stream that was closed.
-        self.stream_id: int | None = None
+    stream_id: int
+    """The Stream ID of the stream that was closed."""
 
     def __repr__(self) -> str:
         return f"<StreamEnded stream_id:{self.stream_id}>"

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -431,6 +431,7 @@ class StreamEnded(Event):
         return f"<StreamEnded stream_id:{self.stream_id}>"
 
 
+@dataclass(**kw_only)
 class StreamReset(Event):
     """
     The StreamReset event is fired in two situations. The first is when the
@@ -442,16 +443,20 @@ class StreamReset(Event):
        This event is now fired when h2 automatically resets a stream.
     """
 
-    def __init__(self) -> None:
-        #: The Stream ID of the stream that was reset.
-        self.stream_id: int | None = None
+    stream_id: int
+    """
+    The Stream ID of the stream that was reset.
+    """
 
-        #: The error code given. Either one of :class:`ErrorCodes
-        #: <h2.errors.ErrorCodes>` or ``int``
-        self.error_code: ErrorCodes | int | None = None
+    error_code: ErrorCodes | int = _LAZY_INIT
+    """
+    The error code given.
+    """
 
-        #: Whether the remote peer sent a RST_STREAM or we did.
-        self.remote_reset = True
+    remote_reset: bool = True
+    """
+    Whether the remote peer sent a RST_STREAM or we did.
+    """
 
     def __repr__(self) -> str:
         return f"<StreamReset stream_id:{self.stream_id}, error_code:{self.error_code!s}, remote_reset:{self.remote_reset}>"

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -235,7 +235,7 @@ class _PushedRequestSent(_HeadersSent):
     """
 
 
-
+@dataclass(**kw_only)
 class InformationalResponseReceived(Event):
     """
     The InformationalResponseReceived event is fired when an informational
@@ -259,20 +259,20 @@ class InformationalResponseReceived(Event):
        Added ``priority_updated`` property.
     """
 
-    def __init__(self) -> None:
-        #: The Stream ID for the stream this informational response was made
-        #: on.
-        self.stream_id: int | None = None
+    stream_id: int
+    """The Stream ID for the stream this informational response was made on."""
 
-        #: The headers for this informational response.
-        self.headers: list[Header] | None = None
+    headers: list[Header] = _LAZY_INIT
+    """The headers for this informational response."""
 
-        #: If this response also had associated priority information, the
-        #: associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
-        #: event will be available here.
-        #:
-        #: .. versionadded:: 2.4.0
-        self.priority_updated: PriorityUpdated | None = None
+    priority_updated: PriorityUpdated | None = None
+    """
+    If this response also had associated priority information, the
+    associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
+    event will be available here.
+
+    .. versionadded:: 2.4.0
+    """
 
     def __repr__(self) -> str:
         return f"<InformationalResponseReceived stream_id:{self.stream_id}, headers:{self.headers}>"

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -45,7 +45,7 @@ class Event:
     """
 
 
-
+@dataclass(**kw_only)
 class RequestReceived(Event):
     """
     The RequestReceived event is fired whenever all of a request's headers
@@ -64,26 +64,29 @@ class RequestReceived(Event):
        Added ``stream_ended`` and ``priority_updated`` properties.
     """
 
-    def __init__(self) -> None:
-        #: The Stream ID for the stream this request was made on.
-        self.stream_id: int | None = None
+    stream_id: int
+    """The Stream ID for the stream this request was made on."""
 
-        #: The request headers.
-        self.headers: list[Header] | None = None
+    headers: list[Header] = _LAZY_INIT
+    """The request headers."""
 
-        #: If this request also ended the stream, the associated
-        #: :class:`StreamEnded <h2.events.StreamEnded>` event will be available
-        #: here.
-        #:
-        #: .. versionadded:: 2.4.0
-        self.stream_ended: StreamEnded | None = None
+    stream_ended: StreamEnded | None = None
+    """
+    If this request also ended the stream, the associated
+    :class:`StreamEnded <h2.events.StreamEnded>` event will be available
+    here.
 
-        #: If this request also had associated priority information, the
-        #: associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
-        #: event will be available here.
-        #:
-        #: .. versionadded:: 2.4.0
-        self.priority_updated: PriorityUpdated | None = None
+    .. versionadded:: 2.4.0
+    """
+
+    priority_updated: PriorityUpdated | None = None
+    """
+    If this request also had associated priority information, the
+    associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
+    event will be available here.
+
+    .. versionadded:: 2.4.0
+    """
 
     def __repr__(self) -> str:
         return f"<RequestReceived stream_id:{self.stream_id}, headers:{self.headers}>"

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -635,6 +635,7 @@ class AlternativeServiceAvailable(Event):
         )
 
 
+@dataclass(**kw_only)
 class UnknownFrameReceived(Event):
     """
     The UnknownFrameReceived event is fired when the remote peer sends a frame
@@ -650,9 +651,7 @@ class UnknownFrameReceived(Event):
     .. versionadded:: 2.7.0
     """
 
-    def __init__(self) -> None:
-        #: The hyperframe Frame object that encapsulates the received frame.
-        self.frame: Frame | None = None
+    frame: Frame
 
     def __repr__(self) -> str:
         return "<UnknownFrameReceived>"

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -403,6 +403,7 @@ class RemoteSettingsChanged(Event):
         )
 
 
+@dataclass(**kw_only)
 class PingReceived(Event):
     """
     The PingReceived event is fired whenever a PING is received. It contains
@@ -412,14 +413,14 @@ class PingReceived(Event):
     .. versionadded:: 3.1.0
     """
 
-    def __init__(self) -> None:
-        #: The data included on the ping.
-        self.ping_data: bytes | None = None
+    ping_data: bytes
+    """The data included on the ping."""
 
     def __repr__(self) -> str:
         return f"<PingReceived ping_data:{_bytes_representation(self.ping_data)}>"
 
 
+@dataclass(**kw_only)
 class PingAckReceived(Event):
     """
     The PingAckReceived event is fired whenever a PING acknowledgment is
@@ -432,9 +433,8 @@ class PingAckReceived(Event):
        Removed deprecated but equivalent ``PingAcknowledged``.
     """
 
-    def __init__(self) -> None:
-        #: The data included on the ping.
-        self.ping_data: bytes | None = None
+    ping_data: bytes
+    """The data included on the ping."""
 
     def __repr__(self) -> str:
         return f"<PingAckReceived ping_data:{_bytes_representation(self.ping_data)}>"

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import binascii
 import sys
 from dataclasses import dataclass
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .settings import ChangedSetting, SettingCodes, Settings, _setting_code_from_int
 
@@ -128,6 +128,7 @@ class ResponseReceived(Event):
         return f"<ResponseReceived stream_id:{self.stream_id}, headers:{self.headers}>"
 
 
+@dataclass(**kw_only)
 class TrailersReceived(Event):
     """
     The TrailersReceived event is fired whenever trailers are received on a
@@ -145,25 +146,28 @@ class TrailersReceived(Event):
        Added ``stream_ended`` and ``priority_updated`` properties.
     """
 
-    def __init__(self) -> None:
-        #: The Stream ID for the stream on which these trailers were received.
-        self.stream_id: int | None = None
+    stream_id: int
+    """The Stream ID for the stream on which these trailers were received."""
 
-        #: The trailers themselves.
-        self.headers: list[Header] | None = None
+    headers: list[Header] = _LAZY_INIT
+    """The trailers themselves."""
 
-        #: Trailers always end streams. This property has the associated
-        #: :class:`StreamEnded <h2.events.StreamEnded>` in it.
-        #:
-        #: .. versionadded:: 2.4.0
-        self.stream_ended: StreamEnded | None = None
+    stream_ended: StreamEnded | None = None
+    """
+    Trailers always end streams. This property has the associated
+    :class:`StreamEnded <h2.events.StreamEnded>` in it.
 
-        #: If the trailers also set associated priority information, the
-        #: associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
-        #: event will be available here.
-        #:
-        #: .. versionadded:: 2.4.0
-        self.priority_updated: PriorityUpdated | None = None
+    .. versionadded:: 2.4.0
+    """
+
+    priority_updated: PriorityUpdated | None = None
+    """
+    If the trailers also set associated priority information, the
+    associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
+    event will be available here.
+
+    .. versionadded:: 2.4.0
+    """
 
     def __repr__(self) -> str:
         return f"<TrailersReceived stream_id:{self.stream_id}, headers:{self.headers}>"

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -340,7 +340,7 @@ class WindowUpdated(Event):
     May be ``0`` if the connection window was changed.
     """
 
-    delta: int | None = None
+    delta: int = _LAZY_INIT
     """
     The window delta.
     """

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -11,6 +11,7 @@ H2 state machine it processes the data and returns a list of Event objects.
 from __future__ import annotations
 
 import binascii
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -21,6 +22,12 @@ if TYPE_CHECKING:  # pragma: no cover
     from hyperframe.frame import Frame
 
     from .errors import ErrorCodes
+
+
+if sys.version_info < (3, 10):  # pragma: no cover
+    kw_only: dict[str, bool] = {}
+else:  # pragma: no cover
+    kw_only = {"kw_only": True}
 
 
 class Event:
@@ -293,7 +300,7 @@ class DataReceived(Event):
         )
 
 
-@dataclass(kw_only=True)
+@dataclass(**kw_only)
 class WindowUpdated(Event):
     """
     The WindowUpdated event is fired whenever a flow control window changes

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -11,6 +11,7 @@ H2 state machine it processes the data and returns a list of Event objects.
 from __future__ import annotations
 
 import binascii
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .settings import ChangedSetting, SettingCodes, Settings, _setting_code_from_int
@@ -292,6 +293,7 @@ class DataReceived(Event):
         )
 
 
+@dataclass(kw_only=True)
 class WindowUpdated(Event):
     """
     The WindowUpdated event is fired whenever a flow control window changes
@@ -301,13 +303,16 @@ class WindowUpdated(Event):
     the connection), and the delta in the window size.
     """
 
-    def __init__(self) -> None:
-        #: The Stream ID of the stream whose flow control window was changed.
-        #: May be ``0`` if the connection window was changed.
-        self.stream_id: int | None = None
+    stream_id: int
+    """
+    The Stream ID of the stream whose flow control window was changed.
+    May be ``0`` if the connection window was changed.
+    """
 
-        #: The window delta.
-        self.delta: int | None = None
+    delta: int | None = None
+    """
+    The window delta.
+    """
 
     def __repr__(self) -> str:
         return f"<WindowUpdated stream_id:{self.stream_id}, delta:{self.delta}>"

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from .settings import ChangedSetting, SettingCodes, Settings, _setting_code_from_int
 
 if TYPE_CHECKING:  # pragma: no cover
-    from hpack import HeaderTuple
+    from hpack.struct import Header
     from hyperframe.frame import Frame
 
     from .errors import ErrorCodes
@@ -52,7 +52,7 @@ class RequestReceived(Event):
         self.stream_id: int | None = None
 
         #: The request headers.
-        self.headers: list[HeaderTuple] | None = None
+        self.headers: list[Header] | None = None
 
         #: If this request also ended the stream, the associated
         #: :class:`StreamEnded <h2.events.StreamEnded>` event will be available
@@ -91,7 +91,7 @@ class ResponseReceived(Event):
         self.stream_id: int | None = None
 
         #: The response headers.
-        self.headers: list[HeaderTuple] | None = None
+        self.headers: list[Header] | None = None
 
         #: If this response also ended the stream, the associated
         #: :class:`StreamEnded <h2.events.StreamEnded>` event will be available
@@ -133,7 +133,7 @@ class TrailersReceived(Event):
         self.stream_id: int | None = None
 
         #: The trailers themselves.
-        self.headers: list[HeaderTuple] | None = None
+        self.headers: list[Header] | None = None
 
         #: Trailers always end streams. This property has the associated
         #: :class:`StreamEnded <h2.events.StreamEnded>` in it.
@@ -237,7 +237,7 @@ class InformationalResponseReceived(Event):
         self.stream_id: int | None = None
 
         #: The headers for this informational response.
-        self.headers: list[HeaderTuple] | None = None
+        self.headers: list[Header] | None = None
 
         #: If this response also had associated priority information, the
         #: associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
@@ -436,7 +436,7 @@ class StreamReset(Event):
 
         #: The error code given. Either one of :class:`ErrorCodes
         #: <h2.errors.ErrorCodes>` or ``int``
-        self.error_code: ErrorCodes | None = None
+        self.error_code: ErrorCodes | int | None = None
 
         #: Whether the remote peer sent a RST_STREAM or we did.
         self.remote_reset = True
@@ -460,7 +460,7 @@ class PushedStreamReceived(Event):
         self.parent_stream_id: int | None = None
 
         #: The request headers, sent by the remote party in the push.
-        self.headers: list[HeaderTuple] | None = None
+        self.headers: list[Header] | None = None
 
     def __repr__(self) -> str:
         return (

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -92,6 +92,7 @@ class RequestReceived(Event):
         return f"<RequestReceived stream_id:{self.stream_id}, headers:{self.headers}>"
 
 
+@dataclass(**kw_only)
 class ResponseReceived(Event):
     """
     The ResponseReceived event is fired whenever response headers are received.
@@ -106,26 +107,29 @@ class ResponseReceived(Event):
       Added ``stream_ended`` and ``priority_updated`` properties.
     """
 
-    def __init__(self) -> None:
-        #: The Stream ID for the stream this response was made on.
-        self.stream_id: int | None = None
+    stream_id: int
+    """The Stream ID for the stream this response was made on."""
 
-        #: The response headers.
-        self.headers: list[Header] | None = None
+    headers: list[Header] = _LAZY_INIT
+    """The response headers."""
 
-        #: If this response also ended the stream, the associated
-        #: :class:`StreamEnded <h2.events.StreamEnded>` event will be available
-        #: here.
-        #:
-        #: .. versionadded:: 2.4.0
-        self.stream_ended: StreamEnded | None = None
+    stream_ended: StreamEnded | None = None
+    """
+    If this response also ended the stream, the associated
+    :class:`StreamEnded <h2.events.StreamEnded>` event will be available
+    here.
 
-        #: If this response also had associated priority information, the
-        #: associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
-        #: event will be available here.
-        #:
-        #: .. versionadded:: 2.4.0
-        self.priority_updated: PriorityUpdated | None = None
+    .. versionadded:: 2.4.0
+    """
+
+    priority_updated: PriorityUpdated | None = None
+    """
+    If this response also had associated priority information, the
+    associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
+    event will be available here.
+
+    .. versionadded:: 2.4.0
+    """
 
     def __repr__(self) -> str:
         return f"<ResponseReceived stream_id:{self.stream_id}, headers:{self.headers}>"

--- a/src/h2/stream.py
+++ b/src/h2/stream.py
@@ -207,7 +207,7 @@ class H2StreamStateMachine:
         if not self.headers_received:
             assert self.client is True
             self.headers_received = True
-            event = ResponseReceived()
+            event = ResponseReceived(stream_id=self.stream_id)
         else:
             assert not self.trailers_received
             self.trailers_received = True

--- a/src/h2/stream.py
+++ b/src/h2/stream.py
@@ -232,9 +232,7 @@ class H2StreamStateMachine:
         """
         Fires when a window update frame is received.
         """
-        event = WindowUpdated()
-        event.stream_id = self.stream_id
-        return [event]
+        return [WindowUpdated(stream_id=self.stream_id)]
 
     def stream_half_closed(self, previous_state: StreamState) -> list[Event]:
         """

--- a/src/h2/stream.py
+++ b/src/h2/stream.py
@@ -195,8 +195,7 @@ class H2StreamStateMachine:
 
         self.client = False
         self.headers_received = True
-        event = RequestReceived()
-        event.stream_id = self.stream_id
+        event = RequestReceived(stream_id=self.stream_id)
         return [event]
 
     def response_received(self, previous_state: StreamState) -> list[Event]:

--- a/src/h2/stream.py
+++ b/src/h2/stream.py
@@ -238,8 +238,7 @@ class H2StreamStateMachine:
         Fires when an END_STREAM flag is received in the OPEN state,
         transitioning this stream to a HALF_CLOSED_REMOTE state.
         """
-        event = StreamEnded()
-        event.stream_id = self.stream_id
+        event = StreamEnded(stream_id=self.stream_id)
         return [event]
 
     def stream_ended(self, previous_state: StreamState) -> list[Event]:
@@ -247,8 +246,7 @@ class H2StreamStateMachine:
         Fires when a stream is cleanly ended.
         """
         self.stream_closed_by = StreamClosedBy.RECV_END_STREAM
-        event = StreamEnded()
-        event.stream_id = self.stream_id
+        event = StreamEnded(stream_id=self.stream_id)
         return [event]
 
     def stream_reset(self, previous_state: StreamState) -> list[Event]:

--- a/src/h2/stream.py
+++ b/src/h2/stream.py
@@ -224,8 +224,7 @@ class H2StreamStateMachine:
         if not self.headers_received:
             msg = "cannot receive data before headers"
             raise ProtocolError(msg)
-        event = DataReceived()
-        event.stream_id = self.stream_id
+        event = DataReceived(stream_id=self.stream_id)
         return [event]
 
     def window_updated(self, previous_state: StreamState) -> list[Event]:

--- a/src/h2/stream.py
+++ b/src/h2/stream.py
@@ -212,7 +212,7 @@ class H2StreamStateMachine:
         else:
             assert not self.trailers_received
             self.trailers_received = True
-            event = TrailersReceived()
+            event = TrailersReceived(stream_id=self.stream_id)
 
         event.stream_id = self.stream_id
         return [event]

--- a/src/h2/stream.py
+++ b/src/h2/stream.py
@@ -424,9 +424,7 @@ class H2StreamStateMachine:
             msg = "Informational response after final response"
             raise ProtocolError(msg)
 
-        event = InformationalResponseReceived()
-        event.stream_id = self.stream_id
-        return [event]
+        return [InformationalResponseReceived(stream_id=self.stream_id)]
 
     def recv_alt_svc(self, previous_state: StreamState) -> list[Event]:
         """

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -172,10 +172,11 @@ class TestEventReprs:
         """
         DataReceived has a useful debug representation.
         """
-        e = h2.events.DataReceived()
-        e.stream_id = 888
-        e.data = b"abcdefghijklmnopqrstuvwxyz"
-        e.flow_controlled_length = 88
+        e = h2.events.DataReceived(
+            stream_id=888,
+            data=b"abcdefghijklmnopqrstuvwxyz",
+            flow_controlled_length=88,
+        )
 
         assert repr(e) == (
             "<DataReceived stream_id:888, flow_controlled_length:88, "

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -159,9 +159,10 @@ class TestEventReprs:
         """
         InformationalResponseReceived has a useful debug representation.
         """
-        e = h2.events.InformationalResponseReceived()
-        e.stream_id = 62
-        e.headers = self.example_informational_headers
+        e = h2.events.InformationalResponseReceived(
+            stream_id=62,
+            headers=self.example_informational_headers,
+        )
 
         assert repr(e) == (
             "<InformationalResponseReceived stream_id:62, headers:["

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -246,10 +246,11 @@ class TestEventReprs:
         """
         StreamEnded has a useful debug representation.
         """
-        e = h2.events.StreamReset()
-        e.stream_id = 919
-        e.error_code = h2.errors.ErrorCodes.ENHANCE_YOUR_CALM
-        e.remote_reset = False
+        e = h2.events.StreamReset(
+            stream_id=919,
+            error_code=h2.errors.ErrorCodes.ENHANCE_YOUR_CALM,
+            remote_reset=False,
+        )
 
         if sys.version_info >= (3, 11):
             assert repr(e) == (

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -186,9 +186,7 @@ class TestEventReprs:
         """
         WindowUpdated has a useful debug representation.
         """
-        e = h2.events.WindowUpdated()
-        e.stream_id = 0
-        e.delta = 2**16
+        e = h2.events.WindowUpdated(stream_id=0, delta=2**16)
 
         assert repr(e) == "<WindowUpdated stream_id:0, delta:65536>"
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -132,9 +132,10 @@ class TestEventReprs:
         """
         ResponseReceived has a useful debug representation.
         """
-        e = h2.events.ResponseReceived()
-        e.stream_id = 500
-        e.headers = self.example_response_headers
+        e = h2.events.ResponseReceived(
+            stream_id=500,
+            headers=self.example_response_headers,
+        )
 
         assert repr(e) == (
             "<ResponseReceived stream_id:500, headers:["

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -115,9 +115,10 @@ class TestEventReprs:
         """
         RequestReceived has a useful debug representation.
         """
-        e = h2.events.RequestReceived()
-        e.stream_id = 5
-        e.headers = self.example_request_headers
+        e = h2.events.RequestReceived(
+            stream_id=5,
+            headers=self.example_request_headers
+        )
 
         assert repr(e) == (
             "<RequestReceived stream_id:5, headers:["

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -222,8 +222,7 @@ class TestEventReprs:
         """
         PingReceived has a useful debug representation.
         """
-        e = h2.events.PingReceived()
-        e.ping_data = b"abcdefgh"
+        e = h2.events.PingReceived(ping_data=b"abcdefgh")
 
         assert repr(e) == "<PingReceived ping_data:6162636465666768>"
 
@@ -231,8 +230,7 @@ class TestEventReprs:
         """
         PingAckReceived has a useful debug representation.
         """
-        e = h2.events.PingAckReceived()
-        e.ping_data = b"abcdefgh"
+        e = h2.events.PingAckReceived(ping_data=b"abcdefgh")
 
         assert repr(e) == "<PingAckReceived ping_data:6162636465666768>"
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import inspect
 import sys
 
+import hyperframe.frame
 import pytest
 from hypothesis import given
 from hypothesis.strategies import integers, lists, tuples
@@ -360,7 +361,7 @@ class TestEventReprs:
         """
         UnknownFrameReceived has a useful debug representation.
         """
-        e = h2.events.UnknownFrameReceived()
+        e = h2.events.UnknownFrameReceived(frame=hyperframe.frame.Frame(1))
         assert repr(e) == "<UnknownFrameReceived>"
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -236,8 +236,7 @@ class TestEventReprs:
         """
         StreamEnded has a useful debug representation.
         """
-        e = h2.events.StreamEnded()
-        e.stream_id = 99
+        e = h2.events.StreamEnded(stream_id=99)
 
         assert repr(e) == "<StreamEnded stream_id:99>"
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -144,9 +144,7 @@ class TestEventReprs:
         """
         TrailersReceived has a useful debug representation.
         """
-        e = h2.events.TrailersReceived()
-        e.stream_id = 62
-        e.headers = self.example_response_headers
+        e = h2.events.TrailersReceived(stream_id=62, headers=self.example_response_headers)
 
         assert repr(e) == (
             "<TrailersReceived stream_id:62, headers:["


### PR DESCRIPTION
This PR adds proper constructors for most of the h2 events. This allows us to tighten the type annotations, simplifying type checks in downstream implementations. These events should not be instantiated by anyone except h2 itself, so it shouldn't be a breaking change.

Based on #1297.