### PR TITLE
Configure RTD builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.13"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ recursive-include examples *.py *.crt *.key *.pem *.csr
 include README.rst LICENSE CHANGELOG.rst pyproject.toml
 
 global-exclude *.pyc *.pyo *.swo *.swp *.map *.yml *.DS_Store
+exclude .readthedocs.yaml

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ to large feature requests and changes.
 Before you contribute (either by opening an issue or filing a pull request),
 please `read the contribution guidelines`_.
 
-.. _read the contribution guidelines: http://python-hyper.org/en/latest/contributing.html
+.. _read the contribution guidelines: https://python-hyper.org/en/latest/contributing.html
 
 License
 =======


### PR DESCRIPTION
Creates minimal RTD config to trigger Sphinx builds. Uses base version matching current tox definition.

RTD builds are not running since months ago. Docs are [not building](https://app.readthedocs.org/projects/hyper-h2/builds/) and updates are [not publishing](https://app.readthedocs.org/projects/hyper-h2/). 

That makes e.g. v4.2.0 release missing from changelog: https://python-hyper.org/projects/hyper-h2/en/latest/release-notes.html#release-history